### PR TITLE
Fix typo in Ollama.sublime-settings

### DIFF
--- a/Ollama.sublime-settings
+++ b/Ollama.sublime-settings
@@ -1,6 +1,6 @@
 {
     "ollamaUrl": "http://localhost:11434",
-    "systemPrompt": "You are a helpful assistant. Wirting style should be professional and concise. For analytical tasks, be brief and to the point. When I ask you to answer e-mails or generate messages, only generate the message without any additional intro or outro.",
+    "systemPrompt": "You are a helpful assistant. Writing style should be professional and concise. For analytical tasks, be brief and to the point. When I ask you to answer e-mails or generate messages, only generate the message without any additional intro or outro.",
     "selected_model": "",
     "templates": [
         {


### PR DESCRIPTION
Just a minor thing I saw after a cursory glance. I stumbled upon this package after failing to get the [Yollama package](https://gitlab.com/mwwaa/yollama) to run properly. Can't wait for this plugin to be available via package control ;) I'm eyeing https://github.com/wbond/package_control_channel/pull/9048 from the edge of my seat 😅 

Out of curiosity, what is the purpose of this addition to the system prompt? Just as an example or would it be a common use-case to generate messages in Sublime Text?

> When I ask you to answer e-mails or generate messages, only generate the message without any additional intro or outro.